### PR TITLE
complete ticket 5 - Added PATCH method to the reviews endpoint

### DIFF
--- a/__tests__/nc-games.test.js
+++ b/__tests__/nc-games.test.js
@@ -85,4 +85,84 @@ describe("/api/reviews/:review_id", () => {
             }) 
         })
     })
+
+    describe("PATCH", () => {
+        test("Status 201: When a valid review_id is passed, if a positive number is passed, increment it by that much", () => {
+
+            return request(app)
+            .post("/api/reviews/2")
+            .send({inc_votes: 20})
+            .expect(201)
+            .then(({ body }) => {
+                const { review } = body; 
+                expect(review).toEqual(
+                    expect.objectContaining({
+                        votes: 25
+                    }))
+            })
+        })
+
+        test("Status 201: When a valid review_id is passed, if a negative number is passed, decrement it by that much", () => {
+
+            return request(app)
+            .post("/api/reviews/4")
+            .send({inc_votes: -3})
+            .expect(201)
+            .then(({ body }) => {
+                const { review } = body; 
+                expect(review).toEqual(
+                    expect.objectContaining({
+                        votes: 4
+                    }))
+            })
+        })
+
+        test("Status 400: When an incorrect data type is input, return status code 400 and 'Invalid review ID type'", () => {
+            return request(app)
+            .post("/api/reviews/thirteen")
+            .expect(400)
+            .send({inc_votes: 13})
+            .then(({ body }) => {
+                const { msg } = body;
+                expect(msg).toBe('Invalid review ID type!')
+            })
+        })
+
+        test("Status 400: When inc_votes is left out/changed, return a status 400 with 'Invalid property'", () => {
+            return request(app)
+            .post("/api/reviews/2")
+            .expect(400)
+            .send({change_votes: 100})
+            .then(({ body }) => {
+                const { msg } = body;
+                expect(msg).toBe('Invalid property!')
+            })
+        })
+
+        test("Status 400: When an non-number data type is posted to inc_votes, return a status 400 with 'Invalid value'", () => {
+            return request(app)
+            .post("/api/reviews/2")
+            .expect(400)
+            .send({inc_votes: "one hundred million"})
+            .then(({ body }) => {
+                const { msg } = body;
+                expect(msg).toBe('Invalid value!')
+            })
+        })
+
+        test("Status 404: When a valid ID is searched but doesn't exist, return status code 404 and 'Review ID does not exist'", () => {
+            return request(app)
+            .post("/api/reviews/40")
+            .expect(404)
+            .send({inc_votes: -100})
+            .then(({ body }) => {
+                const { msg } = body;
+                expect(msg).toBe('Review ID does not exist!')
+            })
+        })
+    })
+
+
+    
+
 })

--- a/__tests__/nc-games.test.js
+++ b/__tests__/nc-games.test.js
@@ -90,7 +90,7 @@ describe("/api/reviews/:review_id", () => {
         test("Status 201: When a valid review_id is passed, if a positive number is passed, increment it by that much", () => {
 
             return request(app)
-            .post("/api/reviews/2")
+            .patch("/api/reviews/2")
             .send({inc_votes: 20})
             .expect(201)
             .then(({ body }) => {
@@ -105,7 +105,7 @@ describe("/api/reviews/:review_id", () => {
         test("Status 201: When a valid review_id is passed, if a negative number is passed, decrement it by that much", () => {
 
             return request(app)
-            .post("/api/reviews/4")
+            .patch("/api/reviews/4")
             .send({inc_votes: -3})
             .expect(201)
             .then(({ body }) => {
@@ -119,7 +119,7 @@ describe("/api/reviews/:review_id", () => {
 
         test("Status 400: When an incorrect data type is input, return status code 400 and 'Invalid review ID type'", () => {
             return request(app)
-            .post("/api/reviews/thirteen")
+            .patch("/api/reviews/thirteen")
             .expect(400)
             .send({inc_votes: 13})
             .then(({ body }) => {
@@ -130,7 +130,7 @@ describe("/api/reviews/:review_id", () => {
 
         test("Status 400: When inc_votes is left out/changed, return a status 400 with 'Invalid property'", () => {
             return request(app)
-            .post("/api/reviews/2")
+            .patch("/api/reviews/2")
             .expect(400)
             .send({change_votes: 100})
             .then(({ body }) => {
@@ -139,9 +139,9 @@ describe("/api/reviews/:review_id", () => {
             })
         })
 
-        test("Status 400: When an non-number data type is posted to inc_votes, return a status 400 with 'Invalid value'", () => {
+        test("Status 400: When an non-number data type is patched to inc_votes, return a status 400 with 'Invalid value'", () => {
             return request(app)
-            .post("/api/reviews/2")
+            .patch("/api/reviews/2")
             .expect(400)
             .send({inc_votes: "one hundred million"})
             .then(({ body }) => {
@@ -152,7 +152,7 @@ describe("/api/reviews/:review_id", () => {
 
         test("Status 404: When a valid ID is searched but doesn't exist, return status code 404 and 'Review ID does not exist'", () => {
             return request(app)
-            .post("/api/reviews/40")
+            .patch("/api/reviews/40")
             .expect(404)
             .send({inc_votes: -100})
             .then(({ body }) => {

--- a/app.js
+++ b/app.js
@@ -1,14 +1,17 @@
 const {
     categoryControllers: { getCategories },
-    reviewControllers: { getReviewById }
+    reviewControllers: { getReviewById, postReview }
 } = require("./controllers/index");
 
 const express = require("express");
 const app = express();
 
+app.use(express.json())
+
 app.get("/api/categories", getCategories);
 
 app.get("/api/reviews/:review_id", getReviewById)
+app.post("/api/reviews/:review_id", postReview)
 
 app.use((err, req, res, next) => {
     const { status, msg } = err;

--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 const {
     categoryControllers: { getCategories },
-    reviewControllers: { getReviewById, postReview }
+    reviewControllers: { getReviewById, patchReview }
 } = require("./controllers/index");
 
 const express = require("express");
@@ -11,7 +11,7 @@ app.use(express.json())
 app.get("/api/categories", getCategories);
 
 app.get("/api/reviews/:review_id", getReviewById)
-app.post("/api/reviews/:review_id", postReview)
+app.patch("/api/reviews/:review_id", patchReview)
 
 app.use((err, req, res, next) => {
     const { status, msg } = err;

--- a/controllers/reviews.js
+++ b/controllers/reviews.js
@@ -12,10 +12,10 @@ exports.getReviewById = (req, res, next) => {
     })
 }
 
-exports.postReview = (req, res, next) => {
+exports.patchReview = (req, res, next) => {
     const { review_id } = req.params
     const { inc_votes } = req.body
-    
+
     updateReview(review_id, inc_votes).then((updatedReview) => {
         res.status(201).send({ review: updatedReview })
     })

--- a/controllers/reviews.js
+++ b/controllers/reviews.js
@@ -1,10 +1,23 @@
-const { fetchReviewById } = require("../models/reviews")
+const { fetchReviewById, 
+        updateReview } = require("../models/reviews")
 
 exports.getReviewById = (req, res, next) => {
     const {review_id} = req.params
 
     fetchReviewById(review_id).then((review) => {
         res.status(200).send({ review })
+    })
+    .catch((err) => {
+        next(err);
+    })
+}
+
+exports.postReview = (req, res, next) => {
+    const { review_id } = req.params
+    const { inc_votes } = req.body
+    
+    updateReview(review_id, inc_votes).then((updatedReview) => {
+        res.status(201).send({ review: updatedReview })
     })
     .catch((err) => {
         next(err);

--- a/models/reviews.js
+++ b/models/reviews.js
@@ -18,3 +18,30 @@ exports.fetchReviewById = (review_id) => {
         return review[0];
     })
 }
+
+exports.updateReview = (review_id, inc_votes) => {
+
+    if(isNaN(parseInt(review_id))){
+        return Promise.reject({status: 400, msg: 'Invalid review ID type!'})
+    } else if (!inc_votes){
+        return Promise.reject({status: 400, msg: "Invalid property!"})
+    } else if (isNaN(parseInt(inc_votes))){
+        return Promise.reject({status: 400, msg: "Invalid value!"})
+    }
+
+    return db.query(`
+        UPDATE reviews
+        SET
+            votes = votes + $2
+        WHERE review_id = $1
+        RETURNING *;
+    `, [review_id, inc_votes])
+    .then(({rows: updatedReview}) => {
+
+        if(!updatedReview.length){
+            return Promise.reject({status: 404, msg: 'Review ID does not exist!'})
+        }
+
+        return updatedReview[0];
+    })
+}


### PR DESCRIPTION
This pull request completes ticket 5.

This branch adds:

- handles a PATCH request for the reviews endpoint, updating the views of a specified review_id by a submitted amount.
- error handling for invalid ID, incorrect data type, incorrect property(not inc_view) and incorrect value data type.

Amended references of post method to now be patch.