### PR TITLE
Compelete ticket 7, adding a comment count property to the existing reviews

### DIFF
--- a/__tests__/nc-games.test.js
+++ b/__tests__/nc-games.test.js
@@ -52,7 +52,8 @@ describe("/api/reviews/:review_id", () => {
                 review_body: 'Farmyard fun!',
                 category: 'euro game',
                 created_at: "2021-01-18T10:00:20.514Z",
-                votes: 1
+                votes: 1,
+                comment_count: "0"
             }
 
             return request(app)
@@ -161,9 +162,6 @@ describe("/api/reviews/:review_id", () => {
             })
         })
     })
-
-
-    
 
 })
 

--- a/models/reviews.js
+++ b/models/reviews.js
@@ -7,8 +7,10 @@ exports.fetchReviewById = (review_id) => {
     }
 
     return db.query(`
-        SELECT * FROM reviews
-        WHERE review_id = $1
+        SELECT reviews.*, COUNT (comment_id) AS comment_count FROM reviews
+        LEFT JOIN comments ON reviews.review_id = comments.review_id
+        WHERE reviews.review_id = $1
+        GROUP BY reviews.review_id;
     `, [review_id]).then(({ rows: review }) => {
 
         if(!review.length){


### PR DESCRIPTION
This pull request completes ticket 7

This branch adds:

- A property to the existing reviews called comment count which returns the amount of comments the review has received.