### PR TITLE
Complete NC-Games Ticket 11:  Add queries to the GET api/reviews endpoint

### DIFF
--- a/controllers/reviews.js
+++ b/controllers/reviews.js
@@ -4,8 +4,12 @@ const { fetchReviewById,
         fetchCommentsByReviewId } = require("../models/reviews")
 
 exports.getReviews = (req, res, next) => {
-    fetchReviews().then((reviews) => {
+    const { sort_by, order, category } = req.query
+    fetchReviews(sort_by, order, category).then((reviews) => {
         res.status(200).send({ reviews })
+    })
+    .catch((err) => {
+        next(err)
     })
 }
 
@@ -16,7 +20,7 @@ exports.getReviewById = (req, res, next) => {
         res.status(200).send({ review })
     })
     .catch((err) => {
-        next(err);
+        next(err)
     })
 }
 
@@ -28,7 +32,7 @@ exports.getCommentsByReviewId = (req, res, next) => {
         res.status(200).send({ comments })
     })
     .catch((err) => {
-        next(err);
+        next(err)
     })
 }
 
@@ -40,7 +44,7 @@ exports.patchReview = (req, res, next) => {
         res.status(201).send({ review: updatedReview })
     })
     .catch((err) => {
-        next(err);
+        next(err)
     })
 }
 


### PR DESCRIPTION
This pull request completes ticket 11.

This branch adds: 

- optional sort_by, order, category queries to the api/reviews endpoint.

Tests:

- Tests for successful intergration of each queries,
- Error handling if queries are passed an invalid column name or value.
- Tests for when category query is valid but no reviews associated to games in that category.