### PR TITLE
Complete Ticket 12 - adds comments/:comment_id endpoint and DELETE HTTP method

### DIFF
--- a/__tests__/nc-games.test.js
+++ b/__tests__/nc-games.test.js
@@ -461,3 +461,33 @@ describe("/api/users", () => {
         })
     })
 })
+
+describe("/api/comments/:comment_id", () => {
+    describe("DELETE", () => {
+        test("Status 204: When a valid comment_id is passed with the delete HTTP method, delete the comment from the database and return a 204 status code", () => {
+            return request(app)
+            .delete("/api/comments/4")
+            .expect(204)
+        })
+
+        test("Status 400: When an invalid comment_id data type is passed return the status code 400 and comment 'Invalid comment_id type'", () => {
+            return request(app)
+            .delete("/api/comments/myComment")
+            .expect(400)
+            .then(({ body }) => {
+                const { msg } = body
+                expect(msg).toBe('Invalid comment_id type!')
+            })
+        })
+
+        test("Status 404: When a valid comment_id is passed but it's not found, return a 404 status code and the message 'Comment not found'", () => {
+            return request(app)
+            .delete("/api/comments/400")
+            .expect(404)
+            .then(({ body }) => {
+                const { msg } = body
+                expect(msg).toBe('Comment not found!')
+            })
+        })
+    }) 
+})

--- a/__tests__/nc-games.test.js
+++ b/__tests__/nc-games.test.js
@@ -464,10 +464,20 @@ describe("/api/users", () => {
 
 describe("/api/comments/:comment_id", () => {
     describe("DELETE", () => {
-        test("Status 204: When a valid comment_id is passed with the delete HTTP method, delete the comment from the database and return a 204 status code", () => {
+        test("Status 204: When a valid comment_id is passed with the delete HTTP method, delete the comment from the database and return a 204 status code.", () => {
             return request(app)
             .delete("/api/comments/4")
             .expect(204)
+            .then(() => {
+                return request(app)
+                .delete("/api/comments/4")
+                .expect(404)
+                .then(({ body }) => {
+                    const { msg } = body
+                    expect(msg).toBe('Comment not found!')
+                })
+            })
+
         })
 
         test("Status 400: When an invalid comment_id data type is passed return the status code 400 and comment 'Invalid comment_id type'", () => {

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ const {
     categoryControllers: { getCategories },
     reviewControllers: { getReviewById, patchReview, getReviews,getCommentsByReviewId },
     userControllers: { getUsers },
-    commentControllers: { postComment }
+    commentControllers: { postComment, deleteCommentById }
 } = require("./controllers/index");
 
 const express = require("express");
@@ -19,6 +19,8 @@ app.get("/api/reviews/:review_id/comments", getCommentsByReviewId)
 app.post("/api/reviews/:review_id/comments", postComment)
 
 app.get("/api/users", getUsers)
+
+app.delete("/api/comments/:comment_id", deleteCommentById)
 
 app.use((err, req, res, next) => {
     const { status, msg } = err;

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -1,10 +1,10 @@
-const { insertComment } = require("../models/comments")
+const { insertComment, removeCommentById } = require("../models/comments")
 const { fetchReviewById } = require("../models/reviews")
 const { retrieveUserByUsername } = require("../models/users")
 
 exports.postComment = (req, res, next) => {
-    const { review_id } = req.params;
-    const {username, body} = req.body;
+    const { review_id } = req.params
+    const {username, body} = req.body
 
     Promise.all([fetchReviewById(review_id), retrieveUserByUsername(username)])
     .then(() => {
@@ -14,6 +14,17 @@ exports.postComment = (req, res, next) => {
         })
     })
     .catch((err) => {
-        next(err);
+        next(err)
+    })
+}
+
+exports.deleteCommentById = (req, res, next) => {
+    const { comment_id } = req.params
+    removeCommentById(comment_id)
+    .then(() => {
+        res.sendStatus(204)
+    })
+    .catch((err) => {
+        next(err)
     })
 }

--- a/models/comments.js
+++ b/models/comments.js
@@ -13,6 +13,23 @@ exports.insertComment = (body, review_id, username) => {
             ($1, $2, $3)
         RETURNING *;`, [body, review_id, username])
         .then(({ rows: [comment] }) => {
-            return comment;
+            return comment
         })
+}
+
+exports.removeCommentById = (comment_id) => {
+    
+    if(isNaN(parseInt(comment_id))){
+        return Promise.reject({status: 400, msg: 'Invalid comment_id type!'})
+    }
+
+    return db.query(`
+        DELETE FROM comments
+        WHERE comment_id = $1
+        RETURNING *`, [comment_id])
+    .then(({ rows: [commentRemoved]}) => {
+        if(!commentRemoved){
+            return Promise.reject({status: 404, msg: "Comment not found!"})
+        }
+    })
 }


### PR DESCRIPTION
This pull request completes ticket 12.

This branch adds:

- comments/:comment_id endpoint with a DELETE HTTP method
- a removeCommentById method

Tests:
- Tests to ensure comment deletion returns the relevent status code.
- Error handling if the comment cannot be deleted i.e. invalid data type or valid id but comment not existing.